### PR TITLE
Updated PHP Parser version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "7.*",
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
-        "nikic/php-parser": "^2.0"
+        "nikic/php-parser": "^2.1|^3.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Tested with `--prefer-lowest`. Seems Yay doesn't actually work with `2.0`, or at least that the tests expect the output of `2.1`. This change means using `--prefer-lowest` continues to work as expected, while `^3.0` is possible for Laravel installations.